### PR TITLE
Use `license` instead of `license-file`

### DIFF
--- a/metastruct/Cargo.toml
+++ b/metastruct/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Abstractions for iterating and mapping over struct fields"
 keywords = ["field", "iterator", "macro"]
 categories = ["rust-patterns"]
-license-file = "../LICENSE"
+license = "Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/sigp/metastruct"
 

--- a/metastruct_macro/Cargo.toml
+++ b/metastruct_macro/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Abstractions for iterating and mapping over struct fields (proc macro crate)"
 keywords = ["field", "iterator", "macro"]
 categories = ["rust-patterns"]
-license-file = "../LICENSE"
+license = "Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/sigp/metastruct"
 


### PR DESCRIPTION
Using `license-file` marks the package as having a non-standard license, even if the license file is straight Apache.